### PR TITLE
Optimize setup steps

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -40,14 +40,14 @@ const questions = [
       'Space ID must be 12 lowercase characters',
   },
   {
-    name: 'managementToken',
-    when: !argv.managementToken,
-    message: 'Your Content Management API access token',
-  },
-  {
     name: 'accessToken',
     when: !argv.accessToken && !process.env.CF_TLD_ACCESS_TOKEN,
     message: 'Your Content Delivery API access token',
+  },
+  {
+    name: 'managementToken',
+    when: !argv.managementToken,
+    message: 'Your Content Management API access token',
   },
 ]
 


### PR DESCRIPTION
The `Content Management API Token` is asked immediately after `Space ID`. The developer has to switch to the `Content Management tokens` tab on the Web app and again return to the `Content delivery/preview tokens ` tab. 
<img width="952" alt="Screenshot 2021-06-23 at 17 01 34" src="https://user-images.githubusercontent.com/1124415/123122768-948d0080-d446-11eb-8ca2-cf82d9617dab.png">

<img width="1267" alt="Screenshot 2021-06-23 at 17 02 35" src="https://user-images.githubusercontent.com/1124415/123122743-8fc84c80-d446-11eb-94ba-eac64c3cb997.png">

It would be nice to have the `Content Delivery API Token` immediately after `Space ID` for better workflow.